### PR TITLE
Minimally viable updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.biggestnerd.radarjammer</groupId>
 	<artifactId>RadarJammer</artifactId>
-	<version>2.4</version>
+	<version>3.0</version>
 	<packaging>jar</packaging>
 
 	<name>RadarJammer</name>
@@ -35,8 +35,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.3</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 		</plugins>
@@ -46,24 +46,24 @@
 		<dependency>
 			<groupId>net.minelink</groupId>
 			<artifactId>CombatTagPlus</artifactId>
-			<version>1.2.3</version>
+			<version>1.3.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
    	 	<dependency>
      		<groupId>com.comphenix.protocol</groupId>
       		<artifactId>ProtocolLib</artifactId>
-      		<version>4.0.2-SNAPSHOT</version>
+      		<version>4.3.0-SNAPSHOT</version>
     	</dependency>
     	<dependency>
     	   <groupId>org.spigotmc</groupId>
     	   <artifactId>spigot</artifactId>
-    	   <version>1.11-R0.1-SNAPSHOT</version>
+    	   <version>1.12-R0.1-SNAPSHOT</version>
     	   <scope>provided</scope>
     	</dependency>
     	<dependency>
     	   <groupId>org.kitteh</groupId>
     	   <artifactId>VanishNoPacket</artifactId>
-    	   <version>3.19.1</version>
+    	   <version>4.0</version>
     	   <scope>provided</scope>
     	</dependency>
 	</dependencies>

--- a/src/com/biggestnerd/radarjammer/VisibilityManager.java
+++ b/src/com/biggestnerd/radarjammer/VisibilityManager.java
@@ -21,7 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
-import org.bukkit.craftbukkit.v1_11_R1.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftPlayer;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.FallingBlock;
@@ -54,7 +54,7 @@ import com.comphenix.protocol.events.PacketAdapter;
 import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.events.PacketEvent;
 
-import net.minecraft.server.v1_11_R1.SoundCategory;
+import net.minecraft.server.v1_12_R1.SoundCategory;
 
 public class VisibilityManager extends BukkitRunnable implements Listener{
 	


### PR DESCRIPTION
using custom VanishNoPacket hosted by DevotedMC and anticipated release for 1.12 of CombatTagPlus currently in a PR on their repo.

Custom VanishNoPacket version: https://github.com/DevotedMC/VanishNoPacket/tree/mc1.12

Custom / anticipated CTP version: https://github.com/MinelinkNetwork/CombatTagPlus/pull/114